### PR TITLE
Build with GHC 8.10

### DIFF
--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -80,7 +80,7 @@ library
       FlexibleInstances
 
   build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 4.15
+               , base       >= 4.3 && < 4.16
                , containers >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 0.11
                , array      >= 0.3 && < 0.6


### PR DESCRIPTION
As long as I reviewed the changes in base from GHC 8.8 to GHC 8.10, there are no problems.
Ref. https://gitlab.haskell.org/ghc/ghc/-/compare/ghc-8.10.1-release...ghc-8.8.3-release#1568a0a0f0272fbf0181fcaea271bc2f1805879e