### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -82,7 +82,7 @@ library
   build-depends: regex-base == 0.94.*
                , base       >= 4.3 && < 4.15
                , containers >= 0.4 && < 0.7
-               , bytestring >= 0.9 && < 0.11
+               , bytestring >= 0.9 && < 0.12
                , array      >= 0.3 && < 0.6
 
   if !impl(ghc >= 8)


### PR DESCRIPTION
Tested using
```cabal
packages: .

constraints:
  bytestring >= 0.11

allow-newer:
  regex-base:bytestring
```