### PR TITLE
Require regex-posix-clib on windows directly (fixes #4, #7)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
 For versioning policy, see: http://pvp.haskell.org/faq
 
-## 0.96.0.1
+## 0.96.0.1 (2021-07-19)
 
-- Compatibility with `base-4.15` (GHC 9.2)
+- Compatibility with `base-4.16` (GHC 9.2)
 - Fix stack installation problems on Windows around flag `_regex-posix-clib`
   (issues
   [#4](https://github.com/haskell-hvr/regex-posix/issues/4) and

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,17 +1,23 @@
-See also http://pvp.haskell.org/faq
+For versioning policy, see: http://pvp.haskell.org/faq
 
-## 0.96.0.0 Revision 2
+## 0.96.0.1
+
+- Compatibility with `base-4.15` (GHC 9.2)
+- Fix stack installation problems on Windows around flag `_regex-posix-clib`
+  (issues
+  [#4](https://github.com/haskell-hvr/regex-posix/issues/4) and
+  [#7](https://github.com/haskell-hvr/regex-posix/issues/7)).
+
+## 0.96.0.0 Revision 2 (2021-02-20)
 
 - Compatibility with `base-4.15` (GHC 9.0)
 
-## 0.96.0.0 Revision 1
+## 0.96.0.0 Revision 1 (2020-03-25)
 
 - Compatibility with `base-4.14` (GHC 8.10)
 
-## 0.96.0.0
+## 0.96.0.0 (2019-09-30)
 
 - Update to `regex-base-0.94.0.0` API
 - Compatibility with `base-4.13.0`
 - Remove internal regex C implementation
-
-----

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -94,7 +94,7 @@ library
                , bytestring >= 0.9 && < 0.12
                , array      >= 0.3 && < 0.6
 
-  if !impl(ghc >= 8)
+  if impl(ghc < 8)
       build-depends: fail == 4.9.*
 
   ghc-options: -O2

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -89,7 +89,7 @@ library
       FlexibleInstances
 
   build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 4.16
+               , base       >= 4.3 && < 4.17
                , containers >= 0.4 && < 0.7
                , bytestring >= 0.9 && < 0.12
                , array      >= 0.3 && < 0.6

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -51,7 +51,7 @@ source-repository this
 flag _regex-posix-clib
   manual: False
   default: False
-  description: Use <//hackage.haskell.org/package/regex-posix-clib regex-posix-clib> package
+  description: Use <//hackage.haskell.org/package/regex-posix-clib regex-posix-clib> package (used by default on Windows)
 
 library
   hs-source-dirs: src
@@ -69,13 +69,10 @@ library
   c-sources:        cbits/myfree.c
   include-dirs:     cbits
 
-  if flag(_regex-posix-clib)
+  if flag(_regex-posix-clib) || os(windows)
     build-depends: regex-posix-clib == 2.7.*
-  else
-    -- use POSIX.2 regex implementation from @libc@
-    -- However, Windows/msys2 doesn't provide a POSIX.2 regex impl in its @libc@
-    if os(windows)
-      build-depends: base<0
+    -- Otherwise, use POSIX.2 regex implementation from @libc@.
+    -- However, Windows/msys2 doesn't provide a POSIX.2 regex impl in its @libc@.
 
   default-language: Haskell2010
   default-extensions:

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -97,5 +97,12 @@ library
   if impl(ghc < 8)
       build-depends: fail == 4.9.*
 
-  ghc-options: -O2
-               -Wall -fno-warn-unused-imports
+  -- Warnings
+
+  ghc-options:
+      -Wall
+      -fno-warn-unused-imports
+
+  if impl(ghc >= 8)
+    ghc-options:
+      -Wcompat

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -1,14 +1,13 @@
 cabal-version:          1.12
 name:                   regex-posix
-version:                0.96.0.0
-x-revision:             2
+version:                0.96.0.1
 
 build-type:             Simple
 license:                BSD3
 license-file:           LICENSE
 copyright:              Copyright (c) 2007-2010, Christopher Kuklewicz
 author:                 Christopher Kuklewicz
-maintainer:             hvr@gnu.org
+maintainer:             hvr@gnu.org, Andreas Abel
 bug-reports:            https://github.com/hvr/regex-posix
 synopsis:               POSIX Backend for "Text.Regex" (regex-base)
 category:               Text
@@ -46,7 +45,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/hvr/regex-base.git
-  tag:      v0.96.0.0-r2
+  tag:      v0.96.0.1
 
 flag _regex-posix-clib
   manual: False

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -85,6 +85,7 @@ library
       GeneralizedNewtypeDeriving
       FlexibleContexts
       TypeSynonymInstances
+         -- ^ for ghc 7.0, subsumed under FlexibleInstances later
       FlexibleInstances
 
   build-depends: regex-base == 0.94.*

--- a/src/Text/Regex/Posix.hs
+++ b/src/Text/Regex/Posix.hs
@@ -5,8 +5,8 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- Module that provides the Regex backend that wraps the

--- a/src/Text/Regex/Posix.hs
+++ b/src/Text/Regex/Posix.hs
@@ -3,7 +3,7 @@
 --
 -- Module      :  Text.Regex.Posix
 -- Copyright   :  (c) Chris Kuklewicz 2006
--- SPDX-License-Identifier: BSD-3-Clause
+-- License     :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable

--- a/src/Text/Regex/Posix/ByteString.hs
+++ b/src/Text/Regex/Posix/ByteString.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Text.Regex.Posix.ByteString
 -- Copyright   :  (c) Chris Kuklewicz 2006
--- SPDX-License-Identifier: BSD-3-Clause
+-- License     :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable

--- a/src/Text/Regex/Posix/ByteString.hs
+++ b/src/Text/Regex/Posix/ByteString.hs
@@ -81,7 +81,7 @@ instance RegexMaker Regex CompOption ExecOption ByteString where
 instance RegexLike Regex ByteString where
   matchTest regex bs = unsafePerformIO $
     asCString bs (wrapTest regex) >>=  unwrap
-  matchOnce regex bs = unsafePerformIO $ 
+  matchOnce regex bs = unsafePerformIO $
     execute regex bs >>= unwrap
   matchAll regex bs = unsafePerformIO $
     asCString bs (wrapMatchAll regex) >>= unwrap
@@ -115,7 +115,7 @@ execute regex bs = do
   case maybeStartEnd of
     Right Nothing -> return (Right Nothing)
 --  Right (Just []) -> ...
-    Right (Just parts) -> 
+    Right (Just parts) ->
       return . Right . Just . listArray (0,pred (length parts))
       . map (\(s,e)->(fromIntegral s, fromIntegral (e-s))) $ parts
     Left err -> return (Left err)
@@ -127,7 +127,7 @@ regexec regex bs = do
   let getSub (start,stop) | start == unusedRegOffset = B.empty
                           | otherwise = B.take (fi (stop-start)) . B.drop (fi start) $ bs
       matchedParts [] = (B.empty,B.empty,bs,[]) -- no information
-      matchedParts (matchedStartStop@(start,stop):subStartStop) = 
+      matchedParts (matchedStartStop@(start,stop):subStartStop) =
         (B.take (fi start) bs
         ,getSub matchedStartStop
         ,B.drop (fi stop) bs

--- a/src/Text/Regex/Posix/ByteString.hs
+++ b/src/Text/Regex/Posix/ByteString.hs
@@ -4,9 +4,9 @@
 -- Module      :  Text.Regex.Posix.ByteString
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
--- 
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+--
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- This provides 'ByteString' instances for RegexMaker and RegexLike

--- a/src/Text/Regex/Posix/ByteString/Lazy.hs
+++ b/src/Text/Regex/Posix/ByteString/Lazy.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Text.Regex.Posix.ByteString.Lazy
 -- Copyright   :  (c) Chris Kuklewicz 2007
--- SPDX-License-Identifier: BSD-3-Clause
+-- License     :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable

--- a/src/Text/Regex/Posix/ByteString/Lazy.hs
+++ b/src/Text/Regex/Posix/ByteString/Lazy.hs
@@ -93,7 +93,7 @@ instance RegexMaker Regex CompOption ExecOption L.ByteString where
 instance RegexLike Regex L.ByteString where
   matchTest regex bs = unsafePerformIO $
     asCString bs (wrapTest regex) >>=  unwrap
-  matchOnce regex bs = unsafePerformIO $ 
+  matchOnce regex bs = unsafePerformIO $
     execute regex bs >>= unwrap
   matchAll regex bs = unsafePerformIO $
     asCString bs (wrapMatchAll regex) >>= unwrap

--- a/src/Text/Regex/Posix/ByteString/Lazy.hs
+++ b/src/Text/Regex/Posix/ByteString/Lazy.hs
@@ -4,9 +4,9 @@
 -- Module      :  Text.Regex.Posix.ByteString.Lazy
 -- Copyright   :  (c) Chris Kuklewicz 2007
 -- SPDX-License-Identifier: BSD-3-Clause
--- 
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+--
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- This provides 'ByteString.Lazy' instances for RegexMaker and RegexLike

--- a/src/Text/Regex/Posix/Sequence.hs
+++ b/src/Text/Regex/Posix/Sequence.hs
@@ -93,7 +93,7 @@ instance RegexLike Regex (Seq Char) where
 -- compile
 compile  :: CompOption -- ^ Flags (summed together)
          -> ExecOption -- ^ Flags (summed together)
-         -> (Seq Char)     -- ^ The regular expression to compile (ASCII only, no null bytes)
+         -> Seq Char   -- ^ The regular expression to compile (ASCII only, no null bytes)
          -> IO (Either WrapError Regex) -- ^ Returns: the compiled regular expression
 compile flags e pattern =  withSeq pattern (wrapCompile flags e)
 
@@ -102,7 +102,7 @@ compile flags e pattern =  withSeq pattern (wrapCompile flags e)
 
 -- | Matches a regular expression against a string
 execute :: Regex      -- ^ Compiled regular expression
-        -> (Seq Char)     -- ^ (Seq Char) to match against
+        -> Seq Char   -- ^ Text to match against
         -> IO (Either WrapError (Maybe (Array Int (MatchOffset,MatchLength))))
                 -- ^ Returns: 'Nothing' if the regex did not match the
                 -- string, or:
@@ -126,8 +126,8 @@ execute regex str = do
 
 -- | Matches a regular expression against a string
 regexec :: Regex      -- ^ Compiled regular expression
-        -> (Seq Char)     -- ^ (Seq Char) to match against
-        -> IO (Either WrapError (Maybe ((Seq Char), (Seq Char), (Seq Char), [(Seq Char)])))
+        -> Seq Char   -- ^ Text to match against
+        -> IO (Either WrapError (Maybe (Seq Char, Seq Char, Seq Char, [Seq Char])))
                 -- ^ Returns: 'Nothing' if the regex did not match the
                 -- string, or:
                 --
@@ -138,11 +138,11 @@ regexec :: Regex      -- ^ Compiled regular expression
                 --         subexpression matches)
                 -- @
 regexec regex str = do
-  let getSub :: (RegOffset,RegOffset) -> (Seq Char)
+  let getSub :: (RegOffset,RegOffset) -> Seq Char
       getSub (start,stop) | start == unusedRegOffset = S.empty
-                          | otherwise = 
+                          | otherwise =
         extract (fromEnum start,fromEnum $ stop-start) $ str
-      matchedParts :: [(RegOffset,RegOffset)] -> ((Seq Char), (Seq Char), (Seq Char), [(Seq Char)])
+      matchedParts :: [(RegOffset,RegOffset)] -> (Seq Char, Seq Char, Seq Char, [Seq Char])
       matchedParts [] = (str,S.empty,S.empty,[]) -- no information
       matchedParts (matchedStartStop@(start,stop):subStartStop) =
         (before (fromEnum start) str

--- a/src/Text/Regex/Posix/Sequence.hs
+++ b/src/Text/Regex/Posix/Sequence.hs
@@ -4,9 +4,9 @@
 -- Module      :  Text.Regex.Posix.Sequence
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
--- 
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+--
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- This provides 'String' instances for 'RegexMaker' and 'RegexLike' based

--- a/src/Text/Regex/Posix/Sequence.hs
+++ b/src/Text/Regex/Posix/Sequence.hs
@@ -77,15 +77,15 @@ unwrap x = case x of Left err -> fail ("Text.Regex.Posix.Sequence died: "++ show
 instance RegexMaker Regex CompOption ExecOption (Seq Char) where
   makeRegexOpts c e pattern = unsafePerformIO $
     (compile c e pattern >>= unwrap)
-  makeRegexOptsM c e pattern = either (fail.show) return $ unsafePerformIO $ 
+  makeRegexOptsM c e pattern = either (fail.show) return $ unsafePerformIO $
     (compile c e pattern)
 
 instance RegexLike Regex (Seq Char) where
   matchTest regex str = unsafePerformIO $ do
     withSeq str (wrapTest regex) >>= unwrap
-  matchOnce regex str = unsafePerformIO $ 
+  matchOnce regex str = unsafePerformIO $
     execute regex str >>= unwrap
-  matchAll regex str = unsafePerformIO $ 
+  matchAll regex str = unsafePerformIO $
     withSeq str (wrapMatchAll regex) >>= unwrap
   matchCount regex str = unsafePerformIO $
     withSeq str (wrapCount regex) >>= unwrap
@@ -116,7 +116,7 @@ execute regex str = do
     Right Nothing -> return (Right Nothing)
 --  Right (Just []) ->  fail "got [] back!" -- return wierd array instead
     Right (Just parts) ->
-      return . Right . Just . listArray (0,pred (length parts)) 
+      return . Right . Just . listArray (0,pred (length parts))
        . map (\(s,e)->(fromIntegral s, fromIntegral (e-s)))
        $ parts
     Left err -> return (Left err)
@@ -144,7 +144,7 @@ regexec regex str = do
         extract (fromEnum start,fromEnum $ stop-start) $ str
       matchedParts :: [(RegOffset,RegOffset)] -> ((Seq Char), (Seq Char), (Seq Char), [(Seq Char)])
       matchedParts [] = (str,S.empty,S.empty,[]) -- no information
-      matchedParts (matchedStartStop@(start,stop):subStartStop) = 
+      matchedParts (matchedStartStop@(start,stop):subStartStop) =
         (before (fromEnum start) str
         ,getSub matchedStartStop
         ,after (fromEnum stop) str

--- a/src/Text/Regex/Posix/Sequence.hs
+++ b/src/Text/Regex/Posix/Sequence.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Text.Regex.Posix.Sequence
 -- Copyright   :  (c) Chris Kuklewicz 2006
--- SPDX-License-Identifier: BSD-3-Clause
+-- License     :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable

--- a/src/Text/Regex/Posix/String.hs
+++ b/src/Text/Regex/Posix/String.hs
@@ -4,9 +4,9 @@
 -- Module      :  Text.Regex.Posix.String
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
--- 
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+--
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- This provides 'String' instances for 'RegexMaker' and 'RegexLike' based

--- a/src/Text/Regex/Posix/String.hs
+++ b/src/Text/Regex/Posix/String.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Text.Regex.Posix.String
 -- Copyright   :  (c) Chris Kuklewicz 2006
--- SPDX-License-Identifier: BSD-3-Clause
+-- License     :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable

--- a/src/Text/Regex/Posix/String.hs
+++ b/src/Text/Regex/Posix/String.hs
@@ -73,15 +73,15 @@ unwrap x = case x of Left err -> fail ("Text.Regex.Posix.String died: "++ show e
 instance RegexMaker Regex CompOption ExecOption String where
   makeRegexOpts c e pattern = unsafePerformIO $
     (compile c e pattern >>= unwrap)
-  makeRegexOptsM c e pattern = either (fail.show) return $ unsafePerformIO $ 
+  makeRegexOptsM c e pattern = either (fail.show) return $ unsafePerformIO $
     (compile c e pattern)
 
 instance RegexLike Regex String where
   matchTest regex str = unsafePerformIO $ do
     withCAString str (wrapTest regex) >>= unwrap
-  matchOnce regex str = unsafePerformIO $ 
+  matchOnce regex str = unsafePerformIO $
     execute regex str >>= unwrap
-  matchAll regex str = unsafePerformIO $ 
+  matchAll regex str = unsafePerformIO $
     withCAString str (wrapMatchAll regex) >>= unwrap
   matchCount regex str = unsafePerformIO $
     withCAString str (wrapCount regex) >>= unwrap
@@ -112,7 +112,7 @@ execute regex str = do
     Right Nothing -> return (Right Nothing)
 --  Right (Just []) ->  fail "got [] back!" -- return wierd array instead
     Right (Just parts) ->
-      return . Right . Just . listArray (0,pred (length parts)) 
+      return . Right . Just . listArray (0,pred (length parts))
        . map (\(s,e)->(fromIntegral s, fromIntegral (e-s)))
        $ parts
     Left err -> return (Left err)
@@ -135,10 +135,10 @@ regexec :: Regex      -- ^ Compiled regular expression
                 -- @
 regexec regex str = do
   let getSub (start,stop) | start == unusedRegOffset = ""
-                          | otherwise = 
+                          | otherwise =
         genericTake (stop-start) . genericDrop start $ str
       matchedParts [] = (str,"","",[]) -- no information
-      matchedParts (matchedStartStop@(start,stop):subStartStop) = 
+      matchedParts (matchedStartStop@(start,stop):subStartStop) =
         (genericTake start str
         ,getSub matchedStartStop
         ,genericDrop stop str

--- a/src/Text/Regex/Posix/Wrap.hsc
+++ b/src/Text/Regex/Posix/Wrap.hsc
@@ -23,11 +23,11 @@
 -- This module will fail or error only if allocation fails or a nullPtr
 -- is passed in.
 --
--- 2009-January : wrapMatchAll and wrapCount now adjust the execution
--- option execNotBOL after the first result to take into account '\n'
+-- 2009-January : 'wrapMatchAll' and 'wrapCount' now adjust the execution
+-- option 'execNotBOL' after the first result to take into account '\n'
 -- in the text immediately before the next matches. (version 0.93.3)
 --
--- 2009-January : wrapMatchAll and wrapCount have been changed to
+-- 2009-January : 'wrapMatchAll' and 'wrapCount' have been changed to
 -- return all non-overlapping matches, including empty matches even if
 -- they coincide with the end of the previous non-empty match.  The
 -- change is that the first non-empty match no longer terminates the
@@ -125,17 +125,17 @@ try = Control.Exception.try
 
 data CRegex   -- pointer tag for regex_t C type
 
--- | RegOffset is "typedef int regoff_t" on Linux and ultimately "typedef
--- long long __int64_t" on Max OS X.  So rather than saying
+-- | 'RegOffset' is @typedef int regoff_t@ on Linux and ultimately @typedef
+-- long long __int64_t@ on Max OS X.  So rather than saying
 -- 2,147,483,647 is all the length you need, I'll take the larger:
 -- 9,223,372,036,854,775,807 should be enough bytes for anyone, no
 -- need for Integer. The alternative is to compile to different sizes
--- in a platform dependent manner with "type RegOffset = (#type
--- regoff_t)", which I do not want to do.
+-- in a platform dependent manner with @type RegOffset = (#type
+-- regoff_t)@, which I do not want to do.
 --
--- There is also a special value 'unusedRegOffset' :: 'RegOffset' which is
+-- There is also a special value @'unusedRegOffset' :: 'RegOffset'@ which is
 -- (-1) and as a starting index means that the subgroup capture was
--- unused.  Otherwise the RegOffset indicates a character boundary that
+-- unused.  Otherwise the 'RegOffset' indicates a character boundary that
 -- is before the character at that index offset, with the first
 -- character at index offset 0. So starting at 1 and ending at 2 means
 -- to take only the second character.
@@ -170,7 +170,7 @@ newtype CompOption = CompOption CInt deriving (Eq,Show,Num,Bits)
 -- regular expressions.  Option values (and their man 3 regexec names) are
 --
 --  * 'execBlank' which is a complete zero value for all the flags.  This is
---    the blankExecOpt value.
+--    the @blankExecOpt@ value.
 --
 --  * 'execNotBOL' (REG_NOTBOL) can be set to prevent ^ from matching at the
 --    start of the input.
@@ -226,7 +226,7 @@ execBlank = ExecOption 0
 unusedRegOffset :: RegOffset
 unusedRegOffset = (-1)
 
--- | The return code will be retOk when it is the Haskell wrapper and
+-- | The return code will be @retOk@ when it is the Haskell wrapper and
 -- not the underlying library generating the error message.
 type WrapError = (ReturnCode,String)
 
@@ -238,13 +238,13 @@ wrapCompile :: CompOption -- ^ Flags (bitmapped)
 wrapTest :: Regex -> CString
          -> IO (Either WrapError Bool)
 
--- | wrapMatch returns offsets for the begin and end of each capture.
--- Unused captures have offsets of unusedRegOffset which is (-1)
+-- | 'wrapMatch' returns offsets for the begin and end of each capture.
+-- Unused captures have offsets of 'unusedRegOffset' which is (-1).
 wrapMatch :: Regex -> CString
           -> IO (Either WrapError (Maybe [(RegOffset,RegOffset)]))
 
--- | wrapMatchAll returns the offset and length of each capture.
--- Unused captures have an offset of unusedRegOffset which is (-1) and
+-- | 'wrapMatchAll' returns the offset and length of each capture.
+-- Unused captures have an offset of 'unusedRegOffset' which is (-1) and
 -- length of 0.
 wrapMatchAll :: Regex -> CString
              -> IO (Either WrapError [MatchArray])

--- a/src/Text/Regex/Posix/Wrap.hsc
+++ b/src/Text/Regex/Posix/Wrap.hsc
@@ -6,8 +6,8 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006,2007,2008 derived from (c) The University of Glasgow 2002
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org
--- Stability   :  experimental
+-- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
 -- WrapPosix.hsc exports a wrapped version of the ffi imports.  To

--- a/src/Text/Regex/Posix/Wrap.hsc
+++ b/src/Text/Regex/Posix/Wrap.hsc
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Text.Regex.Posix.Wrap
 -- Copyright   :  (c) Chris Kuklewicz 2006,2007,2008 derived from (c) The University of Glasgow 2002
--- SPDX-License-Identifier: BSD-3-Clause
+-- Identifier  :  BSD-3-Clause
 --
 -- Maintainer  :  hvr@gnu.org, Andreas Abel
 -- Stability   :  stable


### PR DESCRIPTION
Require `regex-posix-clib` on windows directly (fix #4, fix #7).

Also:
- switch package to stable
- haddock cosmetics
- source code cosmetics
- remove `-O2` in cabal file
- add `-Wcompat` in cabal file

Release candidate at: https://hackage.haskell.org/package/regex-posix-0.96.0.1/candidate/

TODO:

- [x] wait for `regex-posix-clib` on stackage
- [x] add release date to CHANGELOG
- [x] release to hackage
- [x] tag 0.96.0.1
- [x] wait for stackage nightly to pick it up
- [x] test stack-build from nightly