### PR TITLE
v0.96.0.2: Drop support for GHC 7, make Prelude imports explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /dist-newstyle/
 /cabal.project.local
 /.ghc.environment.*
+/.stack-work/
+/stack*.yaml.lock
+*~
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
-For versioning policy, see: http://pvp.haskell.org/faq
+## 0.96.0.2 (2025-03-02)
+
+- Drop support for GHC 7
+- Make `Prelude` imports explicit, add `LANGUAGE NoImplicitPrelude`
+- Make upper bounds of dependencies major-major (all are shipped with GHC)
+- Tested with GHC 8.0 - 9.12.1
 
 ## 0.96.0.1 Revision 3 (2023-09-28)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-This modile is under this "3 clause" BSD license:
-
 Copyright (c) 2007, Christopher Kuklewicz
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+[![Hackage version](https://img.shields.io/hackage/v/regex-posix.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/regex-posix)
+[![Stackage Nightly](http://stackage.org/package/regex-posix/badge/nightly)](http://stackage.org/nightly/package/regex-posix)
+[![Stackage LTS](http://stackage.org/package/regex-posix/badge/lts)](http://stackage.org/lts/package/regex-posix)
+[![Haskell-CI](https://github.com/haskell-hvr/regex-posix/actions/workflows/haskell-ci.yml/badge.svg?branch=master&event=push)](https://github.com/haskell-hvr/regex-posix/actions/workflows/haskell-ci.yml)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+regex-posix
+===========
+
+[Documentation](https://hackage.haskell.org/package/regex-posix/docs/Text-Regex-Posix.html) on hackage.

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/regex-posix.cabal
+++ b/regex-posix.cabal
@@ -1,7 +1,6 @@
-cabal-version:          1.12
+cabal-version:          1.24
 name:                   regex-posix
-version:                0.96.0.1
-x-revision:             3
+version:                0.96.0.2
 
 build-type:             Simple
 license:                BSD3
@@ -19,8 +18,11 @@ description:
   .
   See also <https://wiki.haskell.org/Regular_expressions> for more information.
 
-extra-source-files:
+extra-doc-files:
+  README.md
   ChangeLog.md
+
+extra-source-files:
   cbits/myfree.h
 
 tested-with:
@@ -45,7 +47,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/haskell-hvr/regex-base.git
-  tag:      v0.96.0.1-r3
+  tag:      v0.96.0.2
 
 flag _regex-posix-clib
   manual: False
@@ -73,32 +75,25 @@ library
     -- Otherwise, use POSIX.2 regex implementation from @libc@.
     -- However, Windows/msys2 doesn't provide a POSIX.2 regex impl in its @libc@.
 
-  default-language: Haskell2010
+  default-language:
+      Haskell2010
   default-extensions:
+      NoImplicitPrelude
       MultiParamTypeClasses
       FunctionalDependencies
       ForeignFunctionInterface
       GeneralizedNewtypeDeriving
       FlexibleContexts
-      TypeSynonymInstances
-         -- ^ for ghc 7.0, subsumed under FlexibleInstances later
       FlexibleInstances
 
-  build-depends: regex-base == 0.94.*
-               , base       >= 4.3 && < 5
-               , containers >= 0.4 && < 0.8
-               , bytestring >= 0.9 && < 0.13
-               , array      >= 0.3 && < 0.6
-
-  if impl(ghc < 8)
-      build-depends: fail == 4.9.*
-
-  -- Warnings
+  build-depends:
+        regex-base == 0.94.*
+      , base       >= 4.9  && < 5
+      , containers >= 0.5  && < 1
+      , bytestring >= 0.10 && < 1
+      , array      >= 0.5  && < 1
 
   ghc-options:
       -Wall
-      -fno-warn-unused-imports
-
-  if impl(ghc >= 8)
-    ghc-options:
       -Wcompat
+      -Wno-orphans

--- a/src/Text/Regex/Posix.hs
+++ b/src/Text/Regex/Posix.hs
@@ -5,7 +5,7 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- License     :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -55,8 +55,7 @@ module Text.Regex.Posix(getVersion_Text_Regex_Posix
   -- ** Wrap, for '=~' and '=~~', types and constants
  ,module Text.Regex.Posix.Wrap) where
 
-import Prelude hiding (fail)
-import Control.Monad.Fail (MonadFail)
+import Prelude ()
 
 import Text.Regex.Posix.Wrap(Regex, CompOption(CompOption),
   ExecOption(ExecOption), (=~), (=~~),
@@ -67,7 +66,7 @@ import Text.Regex.Posix.String()
 import Text.Regex.Posix.Sequence()
 import Text.Regex.Posix.ByteString()
 import Text.Regex.Posix.ByteString.Lazy()
-import Data.Version(Version(..))
+import Data.Version(Version)
 import Text.Regex.Base
 import qualified Paths_regex_posix
 

--- a/src/Text/Regex/Posix/ByteString.hs
+++ b/src/Text/Regex/Posix/ByteString.hs
@@ -1,11 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Regex.Posix.ByteString
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- License     :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -51,7 +50,15 @@ module Text.Regex.Posix.ByteString(
   execNotEOL       -- not at end of line
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Int, Integral, Num, (-), fromIntegral, pred
+  , Either(Left, Right), either
+  , Show(show)
+  , IO, (>>=), return
+  , Maybe(Nothing, Just)
+  , ($), (.), (==), (&&), otherwise, not
+  , (++), length, map
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Data.Array(Array,listArray)

--- a/src/Text/Regex/Posix/ByteString/Lazy.hs
+++ b/src/Text/Regex/Posix/ByteString/Lazy.hs
@@ -1,11 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Regex.Posix.ByteString.Lazy
 -- Copyright   :  (c) Chris Kuklewicz 2007
 -- License     :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -52,7 +51,16 @@ module Text.Regex.Posix.ByteString.Lazy(
   execNotEOL       -- not at end of line
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Int, fromIntegral
+  , Either(Left, Right), either
+  , Show(show)
+  , IO, (>>=), return
+  , Maybe(Nothing, Just)
+  , (.), ($), (==)
+  , (&&), not
+  , (++), map
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Data.Array(Array)

--- a/src/Text/Regex/Posix/Sequence.hs
+++ b/src/Text/Regex/Posix/Sequence.hs
@@ -1,11 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Regex.Posix.Sequence
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- License     :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -48,7 +47,16 @@ module Text.Regex.Posix.Sequence(
   execNotEOL     -- not at end of line
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Char
+  , Int, (-), fromEnum, fromIntegral, pred
+  , Show(show)
+  , Either(Left, Right), either
+  , IO, (>>), (>>=), return
+  , Maybe(Nothing, Just)
+  , ($), (.), (==), otherwise
+  , (++), length, map
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Data.Array(listArray, Array)

--- a/src/Text/Regex/Posix/String.hs
+++ b/src/Text/Regex/Posix/String.hs
@@ -1,11 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Regex.Posix.String
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- License     :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -48,7 +47,18 @@ module Text.Regex.Posix.String(
   execNotEOL     -- not at end of line
   ) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Int, String, IO
+  , Either(Left, Right), either
+  , Maybe(Nothing, Just)
+  , Show(show)
+  , fromIntegral, pred
+  , (.), ($), (==), otherwise
+  , (++), (-)
+  , (>>=), return
+  , length, map
+  )
+
 import Control.Monad.Fail (MonadFail(fail))
 
 import Data.Array(listArray, Array)

--- a/src/Text/Regex/Posix/Wrap.hsc
+++ b/src/Text/Regex/Posix/Wrap.hsc
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -Wall -fno-warn-unused-imports #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -6,7 +7,7 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006,2007,2008 derived from (c) The University of Glasgow 2002
 -- Identifier  :  BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (regex-base needs MPTC+FD)
 --
@@ -97,7 +98,18 @@ module Text.Regex.Posix.Wrap(
 
 #include "myfree.h"
 
-import Prelude hiding (fail)
+import Prelude
+  ( Bool(True, False), otherwise
+  , Either(Left, Right)
+  , Eq, (==), (/=), (>=)
+  , IO, return, mapM
+  , Int, Num, (+), (*), (-), fromIntegral, pred, succ, toEnum
+  , Maybe(Nothing, Just)
+  , Show(show)
+  , String
+  , ($), (.), seq, undefined
+  , (++), iterate, length, map, take
+  )
 import Control.Monad.Fail (MonadFail)
 
 import Control.Monad(liftM)
@@ -106,15 +118,11 @@ import Data.Bits(Bits(..))
 import Data.Int(Int32,Int64)   -- need whatever RegeOffset or #regoff_t type will be
 import Data.Word(Word32,Word64) -- need whatever RegeOffset or #regoff_t type will be
 import Foreign(Ptr, FunPtr, nullPtr, newForeignPtr,
-               addForeignPtrFinalizer, Storable(peekByteOff), allocaArray,
+               Storable(peekByteOff), allocaArray,
                allocaBytes, withForeignPtr,ForeignPtr,plusPtr,peekElemOff)
 import Foreign.Marshal.Alloc(mallocBytes)
 import Foreign.C(CChar)
-#if __GLASGOW_HASKELL__ >= 703
 import Foreign.C(CSize(CSize),CInt(CInt))
-#else
-import Foreign.C(CSize,CInt)
-#endif
 import Foreign.C.String(peekCAString, CString)
 import Text.Regex.Base.RegexLike(RegexOptions(..),RegexMaker(..),RegexContext(..),MatchArray)
 -- deprecated: import qualified System.IO.Error as IOERROR(try)


### PR DESCRIPTION
Harden the implementation against ecosystem changes by making the Prelude imports explicit.
Since there are no practical means to test this against GHC < 8, we drop support for GHC 7 explicitly, bumping to base >= 4.9.
All dependencies of regex-base ship with GHC, so maintaining precise upper bounds is just busy-work. Thus, we make upper-bounds major-major, so we just get the very strong signals of drastic API changes. Usual API changes should not affect this very stable package.